### PR TITLE
fix: Correct syntax error in ExerciseManager

### DIFF
--- a/components/exercise-manager.tsx
+++ b/components/exercise-manager.tsx
@@ -159,7 +159,7 @@ export function ExerciseManager({ workout, userProfile, onSave, onCancel }: Exer
         calories: calculateCaloriesBurned(ex, userProfile.weight, durationMinutes)
       };
     })
-  ));
+  );
 
   // Helper to estimate duration for an exercise based on reps (e.g., 3 seconds per rep)
   const getExerciseDurationMinutes = (reps: number): number => {


### PR DESCRIPTION
This commit fixes a syntax error in `components/exercise-manager.tsx` that occurred during the initialization of the `exercises` state within the `useState` hook. An extraneous parenthesis caused a "Expected a semicolon" error.

The extra parenthesis has been removed, and the related logic for calorie calculation during exercise initialization, addition, and updates has been reviewed and confirmed to be working as intended.